### PR TITLE
Chore/fips cherrypicks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <saxon-he.version>10.9</saxon-he.version>
         <xqj-api.version>1.0</xqj-api.version>
         <guava.version>33.1.0-jre</guava.version>
-        <commons-pool2.version>2.11.1</commons-pool2.version>
+        <commons-pool2.version>2.12.0</commons-pool2.version>
         <xmlunit.version>1.6</xmlunit.version>
 
         <munit.input.directory>src/test/munit</munit.input.directory>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <saxon-he.version>10.8</saxon-he.version>
         <xqj-api.version>1.0</xqj-api.version>
-        <guava.version>32.0.0-jre</guava.version>
+        <guava.version>33.1.0-jre</guava.version>
         <commons-pool2.version>2.11.1</commons-pool2.version>
         <xmlunit.version>1.6</xmlunit.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <munit.input.directory>src/test/munit</munit.input.directory>
         <munit.output.directory>${basedir}/target/test-mule/munit</munit.output.directory>
         <munit.version>2.3.17</munit.version>
-        <mavenResources.version>3.3.0</mavenResources.version>
+        <mavenResources.version>3.3.1</mavenResources.version>
 
         <formatterConfigPath>formatter.xml</formatterConfigPath>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     </description>
 
     <properties>
-        <saxon-he.version>10.8</saxon-he.version>
+        <saxon-he.version>10.9</saxon-he.version>
         <xqj-api.version>1.0</xqj-api.version>
         <guava.version>33.1.0-jre</guava.version>
         <commons-pool2.version>2.11.1</commons-pool2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 
         <!-- JDK 17 Compatibility Props -->
         <munit.extensions.maven.plugin.version>1.2.0</munit.extensions.maven.plugin.version>
-        <jacoco.version>0.8.10</jacoco.version>
+        <jacoco.version>0.8.11</jacoco.version>
         <munit.version>3.1.0-rc3</munit.version>
         <mtf.javaopts></mtf.javaopts>
         <mule-sdk-api.version>0.7.0</mule-sdk-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,6 @@
         <munit.extensions.maven.plugin.version>1.2.0</munit.extensions.maven.plugin.version>
         <jacoco.version>0.8.11</jacoco.version>
         <munit.version>3.1.0</munit.version>
-        <mtf.javaopts></mtf.javaopts>
         <mule-sdk-api.version>0.7.0</mule-sdk-api.version>
         <munit.failIfNoTests>false</munit.failIfNoTests>
     </properties>
@@ -128,11 +127,6 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <environmentVariables>
-                        <!-- Toggles the JDK17 style flag -->
-                        <!-- ugly hack -->
-                        <_JAVA_OPTIONS>-XX:+PrintCommandLineFlags ${mtf.javaopts}</_JAVA_OPTIONS>
-                    </environmentVariables>
                     <argLines>
                         <argLine>
                             -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${session.executionRootDirectory}/target/jacoco.exec

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <formatterConfigPath>formatter.xml</formatterConfigPath>
 
         <!-- JDK 17 Compatibility Props -->
-        <munit.extensions.maven.plugin.version>1.2.0-rc2</munit.extensions.maven.plugin.version>
+        <munit.extensions.maven.plugin.version>1.2.0</munit.extensions.maven.plugin.version>
         <jacoco.version>0.8.10</jacoco.version>
         <munit.version>3.1.0-rc3</munit.version>
         <mtf.javaopts></mtf.javaopts>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <!-- JDK 17 Compatibility Props -->
         <munit.extensions.maven.plugin.version>1.2.0</munit.extensions.maven.plugin.version>
         <jacoco.version>0.8.11</jacoco.version>
-        <munit.version>3.1.0-rc3</munit.version>
+        <munit.version>3.1.0</munit.version>
         <mtf.javaopts></mtf.javaopts>
         <mule-sdk-api.version>0.7.0</mule-sdk-api.version>
         <munit.failIfNoTests>false</munit.failIfNoTests>


### PR DESCRIPTION
I've removed an unsightly hack that we previously employed for executing MTF tests on Java 11, using flags to mimic Java 17 behavior. This hack overrides JAVA_OPTIONS, rendering it incompatible with the FIPS Validation Pipeline.

